### PR TITLE
feature/redesign pq query selector

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,41 +122,50 @@ item *dict*.
 
     class ProductItemModel(ItemModel):
         item_name = parsers.TextParser(
-            pq('.name').text(),
+            pq('.name::text'),
         )
 
         item_brand = parsers.TextParser(
-            pq('.brand').text()
+            pq('.brand::text')
         )
 
         item_description = parsers.DescriptionParser(
-            pq('#description').text()
+            pq('#description::text')
         )
 
         item_price = parsers.PriceFloatParser(
-            pq('#price').text()
+            pq('#price::text')
         )
 
         item_sale_price = parsers.PriceFloatParser(
-            pq('#sale-price').text()
+            pq('#sale-price::text')
         )
 
         item_color = parsers.FeatureParser(
-            pq('#description').text(),
+            pq('#description::text'),
             key='color'
         )
 
+        item_stock = parsers.BoolParser(
+            pq('.stock::attr(available)'),
+            contains=['yes']
+        )
+
         item_images = parsers.ListParser(
-            pq('.images'),
+            pq('.images img::items'),
             parser=parsers.UrlParser(
-                pq('img').attr('src')
+                pq('::src')
             )
         )
 
-        item_stock = parsers.BoolParser(
-            pq('.stock').attr('available'),
-            contains=['yes']
-        )
+        """
+        Alternative with selecting src values in a first css query:
+
+            item_images = parsers.ListParser(
+                pq('.images img::src-items'),
+                parser=parsers.UrlParser()
+            )
+        """
 
 In example bellow we will demonstrate how newly created ``ProductItemModel``
 will parse provided *HTML* data into ``dict`` object.

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -46,11 +46,11 @@ data from the HTML above.
 
     class PricingBlock(Block):
         item_price = parsers.PriceFloat(
-            pq('#price').text
+            pq('#price::text')
         )
 
         item_sale_price = parsers.PriceFloat(
-            pq('#sale-price').text
+            pq('#sale-price::text')
         )
 
         items_processors = [
@@ -73,15 +73,15 @@ lets create our ``ItemModel`` bellow.
         ]
 
         item_name = parsers.TextParser(
-            pq('.name').text(),
+            pq('.name::text'),
         )
 
         item_brand = parsers.TextParser(
-            pq('.brand').text()
+            pq('.brand::text')
         )
 
         item_stock = parsers.BoolParser(
-            pq('.stock').attr('available'),
+            pq('.stock::attr(available)'),
             contains=['yes']
         )
 
@@ -134,7 +134,7 @@ We can also override ``item_price`` from the ``PricingBlock`` in our ``ProductIt
         ]
 
         item_price = parsers.PriceFloat(
-            pq('#price').text
+            pq('#price::text')
         )
 
         ...
@@ -162,11 +162,11 @@ Example:
         ):
 
             self.item_price = parsers.PriceFloat(
-                pq(price_css).text
+                pq(price_css)
             )
 
             self.item_sale_price = parsers.PriceFloat(
-                pq(price_css).text
+                pq(price_css)
             )
 
             if calculate_discount:
@@ -181,8 +181,8 @@ Now lets use ``PricingCssBlock`` in our ``ProductItemModel``.
     class ProductItemModel(ItemModel):
         blocks = [
             PricingCssBlock(
-                price_css='#price',
-                sale_price_css='#sale-price'
+                price_css='#price::text',
+                sale_price_css='#sale-price::text'
             )
         ]
 
@@ -204,11 +204,11 @@ For starters lets create ``Block`` without named item processors.
 
     class PricingBlock(Block):
         item_price = parsers.PriceFloat(
-            pq('#price').text
+            pq('#price::text')
         )
 
         item_sale_price = parsers.PriceFloat(
-            pq('#sale-price').text
+            pq('#sale-price::text')
         )
 
         items_processors = [
@@ -253,11 +253,11 @@ To solve this issue, named processors are the solution. Lets recreate our
 
     class PricingBlock(Block):
         item_price = parsers.PriceFloat(
-            pq('#price').text
+            pq('#price::text')
         )
 
         item_sale_price = parsers.PriceFloat(
-            pq('#sale-price').text
+            pq('#sale-price::text')
         )
 
         items_processors = [
@@ -312,11 +312,11 @@ Lets show this in example below.
 
     class ProductItemModel(ItemModel):
         item_temp_price = parsers.PriceFloat(
-            pq('#price').text
+            pq('#price::text')
         )
 
         item_temp_sale_price = parsers.PriceFloat(
-            pq('#sale-price').text
+            pq('#sale-price::text')
         )
 
         items_processors = [

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -47,7 +47,7 @@ through other components.
         item_price = parsers.PriceFloat(jp('price'))
 
         item_temp_sale_price = parsers.PriceFloat(
-            pq('sale_price'),
+            pq('sale_price::text'),
             source='html'
         )
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -59,7 +59,9 @@ In this example we will use following html:
     """
 
 Now lets create an ``ItemModel`` which will process html above and parse it to
-item dict.
+item dict. To select data in a text parser we will use ``pq``, which is based
+on a PyQuery library and also adds custom pseudo element support like ``::text``,
+``attr()``
 
 .. code-block:: python
 
@@ -70,41 +72,50 @@ item dict.
 
     class ProductItemModel(ItemModel):
         item_name = parsers.TextParser(
-            pq('.name').text(),
+            pq('.name::text'),
         )
 
         item_brand = parsers.TextParser(
-            pq('.brand').text()
+            pq('.brand::text')
         )
 
         item_description = parsers.DescriptionParser(
-            pq('#description').text()
+            pq('#description::text')
         )
 
         item_price = parsers.PriceFloatParser(
-            pq('#price').text()
+            pq('#price::text')
         )
 
         item_sale_price = parsers.PriceFloatParser(
-            pq('#sale-price').text()
+            pq('#sale-price::text')
         )
 
         item_color = parsers.FeatureParser(
-            pq('#description').text(),
+            pq('#description::text'),
             key='color'
         )
 
+        item_stock = parsers.BoolParser(
+            pq('.stock::attr(available)'),
+            contains=['yes']
+        )
+
         item_images = parsers.ListParser(
-            pq('.images'),
+            pq('.images img::items'),
             parser=parsers.UrlParser(
-                pq('img').attr('src')
+                pq('::src')
             )
         )
 
-        item_stock = parsers.BoolParser(
-            pq('.stock').attr('available'),
-            contains=['yes']
-        )
+        """
+        Alternative with selecting src values in a first css query:
+
+            item_images = parsers.ListParser(
+                pq('.images img::src-items'),
+                parser=parsers.UrlParser()
+            )
+        """
 
 
 Parsing data with Model
@@ -244,7 +255,7 @@ Lets create our item model with ``data_processors`` included.
         )
 
         item_css_name = parsers.TextParser(
-            pq('.name').text(),
+            pq('.name::text'),
         )
 
 .. code-block:: python
@@ -301,7 +312,7 @@ because there wouldn't be any HTML data to extract info from.
 .. code-block:: python
 
     item_css_name = parsers.TextParser(
-        pq('.name').text(),
+        pq('.name::text'),
     )
 
 We can also specify multiple data processors if needed:
@@ -369,19 +380,19 @@ Lets create our item model with ``items_processors``
 
     class ProductItemModel(ItemModel):
         item_name = parsers.TextParser(
-            pq('#name', rm='.brand').text()
+            pq('#name::text', rm='.brand')
         )
 
         item_brand = parsers.TextParser(
-            pq('.brand').text()
+            pq('.brand::text')
         )
 
         item_price = parsers.PriceFloatParser(
-            pq('#price').text()
+            pq('#price::text')
         )
 
         item_sale_price = parsers.PriceFloatParser(
-            pq('#sale-price').text()
+            pq('#sale-price::text')
         )
 
         items_processors = [

--- a/docs/parsers/clause.rst
+++ b/docs/parsers/clause.rst
@@ -27,8 +27,8 @@ Lets write our ``Union`` parser.
     '''
 
     union_parser = parsers.Union(
-        parsers.Text(pq('.brand-wrong-selector').text),
-        parsers.Text(pq('.brand').text)
+        parsers.Text(pq('.brand-wrong-selector::text')),
+        parsers.Text(pq('.brand::text'))
     )
 
 Now lets parse ``test_html`` data and print our result.
@@ -41,7 +41,7 @@ Now lets parse ``test_html`` data and print our result.
 
     'EasyData'
 
-First our ``parsers.Text(pq('.brand-wrong-selector').text),`` output was ``None``,
+First our ``parsers.Text(pq('.brand-wrong-selector::text')),`` output was ``None``,
 while next ``Text`` parser in line has produced output, since it's selector was able
 to extract data from ``HTML``.
 
@@ -58,8 +58,8 @@ Please note that even if query selector found a match and it's content was still
     '''
 
     union_parser = parsers.Union(
-        parsers.Text(pq('#name').text),
-        parsers.Text(pq('.brand').text)
+        parsers.Text(pq('#name::text')),
+        parsers.Text(pq('.brand::text'))
     )
 
 Now lets parse ``test_html`` data and print our result.
@@ -107,7 +107,7 @@ Lets write our ``With`` parser.
 
     with_parser = parsers.With(
         parsers.Sentences(
-            pq('#description .features').text,
+            pq('#description .features::text'),
             allow=['date added']
         ),
         parsers.DateTimeSearch()
@@ -150,8 +150,8 @@ Lets write our ``JoinText`` parser.
     '''
 
     join_text_parser = parsers.JoinText(
-        parsers.Text(pq('#name').text),
-        parsers.Text(pq('.brand').text)
+        parsers.Text(pq('#name::text')),
+        parsers.Text(pq('.brand::text'))
     )
 
 Now lets parse ``test_html`` data and print our result.

--- a/docs/parsers/list.rst
+++ b/docs/parsers/list.rst
@@ -113,16 +113,16 @@ object through which we can use css selectors.
 .. code-block:: python
 
     list_parser = parsers.List(
-        pq('#images img'),
-        parser=parsers.Url(pq.attr('src'))
+        pq('#images img::items'),
+        parser=parsers.Url(pq('::src'))
     )
 
-Please note that ``pq('#images img')`` will be iterated through our ``List``
+Please note that ``pq('#images img::items')`` will be iterated through our ``List``
 parser and that img html node object will be passed to ``Url`` parser upon which
 ``pq`` query selector can be used again to output final result. Since in example
-above in our ``List`` parser, we already selected with css img html node, there
-is no need to use css selector again in ``Url`` parser and therefore we just
-tell ``pq`` query selector to get data from ``src`` attribute.
+above in our ``List`` parser, we already selected with css img html node, so in
+``Url`` parser we just add into query selector ``::src`` pseudo element in order
+to get data from ``src`` attribute in HTML element.
 
 Now lets parse ``test_html_text`` data and print our result.
 

--- a/easydata/queries/pq.py
+++ b/easydata/queries/pq.py
@@ -7,16 +7,15 @@ from easydata.data import DataBag
 from easydata.queries.base import QuerySearch
 
 _attr_shortcut_mappings = {
-    'val': 'value',
-    'src': 'src',
-    'href': 'href',
-    'name': 'name',
-    'content': 'content'
+    "val": "value",
+    "src": "src",
+    "href": "href",
+    "name": "name",
+    "content": "content",
 }
 
 
 class PyQuerySearch(QuerySearch):
-
     def __init__(
         self,
         query: Optional[str] = None,
@@ -144,6 +143,6 @@ class PyQuerySearch(QuerySearch):
                 "Pseudo type '{}' is not supported for extraction type. Currently "
                 "supported are: text,ntext,html,items,<pseudo el>-items, "
                 "attr(<value>),{}".format(
-                    pseudo_key, ','.join(_attr_shortcut_mappings.keys())
+                    pseudo_key, ",".join(_attr_shortcut_mappings.keys())
                 )
             )

--- a/tests/factory/blocks.py
+++ b/tests/factory/blocks.py
@@ -5,9 +5,9 @@ from easydata.queries import pq
 
 
 class PricingBlock(Block):
-    item_price = parsers.PriceFloat(pq("#price").text)
+    item_price = parsers.PriceFloat(pq("#price::text"))
 
-    item_sale_price = parsers.PriceFloat(pq("#sale-price").text)
+    item_sale_price = parsers.PriceFloat(pq("#sale-price::text"))
 
     items_processors = [("discount", ItemDiscountProcessor())]
 

--- a/tests/factory/models.py
+++ b/tests/factory/models.py
@@ -13,7 +13,7 @@ class ProductModel(ItemModel):
 
     item_designer = parsers.Text(from_item="brand")
 
-    item_name = parsers.Text(pq(".name").text)
+    item_name = parsers.Text(pq(".name::text"))
 
     def item_stock(self, data):
         return data["json_data"]["info"]["stock"]

--- a/tests/parsers/test_bool.py
+++ b/tests/parsers/test_bool.py
@@ -66,8 +66,8 @@ def test_bool_contains_case(ccontains_keys, test_data, result):
 @pytest.mark.parametrize(
     "query, contains_query, test_data, result",
     [
-        (pq("#full-name").text, pq(".brand").text, date_test_text, False),
-        (pq("#full-name").text, pq(".brand").text.items, date_test_text, False),
+        (pq("#full-name::text"), pq(".brand::text"), date_test_text, False),
+        (pq("#full-name::text"), pq(".brand::text-items"), date_test_text, False),
     ],
 )
 def test_bool_contains_query(query, contains_query, test_data, result):

--- a/tests/parsers/test_clause.py
+++ b/tests/parsers/test_clause.py
@@ -11,7 +11,8 @@ def test_union():
     """
 
     union_parser = parsers.Union(
-        parsers.Text(pq(".brand-wrong").text), parsers.Text(pq(".brand").text)
+        parsers.Text(pq(".brand-wrong::text")),
+        parsers.Text(pq(".brand::text")),
     )
     assert union_parser.parse(test_html) == "EasyData"
 
@@ -23,7 +24,8 @@ def test_union_first():
     """
 
     union_parser = parsers.Union(
-        parsers.Text(pq(".brand").text), parsers.Text(pq("#name").text)
+        parsers.Text(pq(".brand::text")),
+        parsers.Text(pq("#name::text")),
     )
     assert union_parser.parse(test_html) == "EasyData"
 
@@ -34,8 +36,8 @@ def test_union_none():
     """
 
     union_parser = parsers.Union(
-        parsers.Text(pq(".brand-wrong").text),
-        parsers.Text(pq(".brand-wrong-again").text),
+        parsers.Text(pq(".brand-wrong::text")),
+        parsers.Text(pq(".brand-wrong-again::text")),
     )
     assert union_parser.parse(test_html) is None
 
@@ -52,13 +54,13 @@ def test_with():
     """
 
     with_parser = parsers.With(
-        parsers.Sentences(pq("#description .features").text, allow=["date added"]),
+        parsers.Sentences(pq("#description .features::text"), allow=["date added"]),
         parsers.DateTimeSearch(),
     )
     assert with_parser.parse(test_html) == "12/12/2018 10:55:00"
 
     with_parser = parsers.With(
-        parsers.Sentences(pq("#description .features").text, allow=["date added"]),
+        parsers.Sentences(pq("#description .features::text"), allow=["date added"]),
         parsers.Text(split_key=("added:", -1)),
         parsers.DateTime(),
     )
@@ -72,12 +74,13 @@ def test_join_text():
     """
 
     join_text_parser = parsers.JoinText(
-        parsers.Text(pq(".brand").text), parsers.Text(pq("#name").text)
+        parsers.Text(pq(".brand::text")), parsers.Text(pq("#name::text"))
     )
     assert join_text_parser.parse(test_html) == "EasyData Easybook Pro 13"
 
     join_text_parser = parsers.JoinText(
-        parsers.Text(pq(".brand-wrong-selector").text), parsers.Text(pq("#name").text)
+        parsers.Text(pq(".brand-wrong-selector::text")),
+        parsers.Text(pq("#name::text"))
     )
     assert join_text_parser.parse(test_html) == "Easybook Pro 13"
 
@@ -89,7 +92,7 @@ def test_join_text_custom_separator():
     """
 
     join_text_parser = parsers.JoinText(
-        parsers.Text(pq(".brand").text), parsers.Text(pq("#name").text), separator="-"
+        parsers.Text(pq(".brand::text")), parsers.Text(pq("#name::text")), separator="-"
     )
     assert join_text_parser.parse(test_html) == "EasyData-Easybook Pro 13"
 

--- a/tests/parsers/test_clause.py
+++ b/tests/parsers/test_clause.py
@@ -79,8 +79,7 @@ def test_join_text():
     assert join_text_parser.parse(test_html) == "EasyData Easybook Pro 13"
 
     join_text_parser = parsers.JoinText(
-        parsers.Text(pq(".brand-wrong-selector::text")),
-        parsers.Text(pq("#name::text"))
+        parsers.Text(pq(".brand-wrong-selector::text")), parsers.Text(pq("#name::text"))
     )
     assert join_text_parser.parse(test_html) == "Easybook Pro 13"
 

--- a/tests/parsers/test_dict.py
+++ b/tests/parsers/test_dict.py
@@ -25,26 +25,26 @@ test_dict_sizes = {"sizes": {"l": True, "xl": False, "xxl": True}}
 
 def test_dict():
     dict_parser = parsers.Dict(
-        pq("#size-variants li").items,
-        key_parser=parsers.Text(pq().text),
-        value_parser=parsers.Bool(pq().attr("size-stock"), contains=["true"]),
+        pq("#size-variants li::items"),
+        key_parser=parsers.Text(pq("::text")),
+        value_parser=parsers.Bool(pq("::attr(size-stock)"), contains=["true"]),
     )
 
     expected_result = {"l": True, "xl": False, "xxl": True}
     assert dict_parser.parse(test_html) == expected_result
 
     dict_parser = parsers.Dict(
-        pq("#size-variants li").items,
-        key_query=pq().text,
-        value_parser=parsers.Bool(pq().attr("size-stock"), contains=["true"]),
+        pq("#size-variants li::items"),
+        key_query=pq("::text"),
+        value_parser=parsers.Bool(pq("::attr(size-stock)"), contains=["true"]),
     )
 
     assert dict_parser.parse(test_html) == expected_result
 
     dict_parser = parsers.Dict(
-        pq("#size-variants li").items,
-        key_query=pq().text,
-        value_query=pq().attr("size-stock"),
+        pq("#size-variants li::items"),
+        key_query=pq("::text"),
+        value_query=pq("::attr(size-stock)"),
     )
 
     expected_text_result = {"l": "true", "xl": "false", "xxl": "true"}
@@ -78,9 +78,9 @@ def test_dict():
 
 def test_bool_dict():
     bool_dict_parser = parsers.BoolDict(
-        pq("#size-variants li").items,
-        key_query=pq().text,
-        value_query=pq().attr("size-stock"),
+        pq("#size-variants li::items"),
+        key_query=pq("::text"),
+        value_query=pq("::attr(size-stock)"),
     )
 
     expected_text_result = {"l": True, "xl": False, "xxl": True}

--- a/tests/parsers/test_list.py
+++ b/tests/parsers/test_list.py
@@ -34,26 +34,29 @@ expected_urls_non_unique = [
 expected_urls_max_2 = ["https://demo.com/imgs/1.jpg", "https://demo.com/imgs/2.jpg"]
 
 
-def test_list_field():
-    list_parser = parsers.List(pq("#images img").items, parsers.Url(pq(attr="src")))
+def test_list():
+    list_parser = parsers.List(
+        pq("#images img::items"),
+        parsers.Url(pq("::src"))
+    )
 
     assert list_parser.parse(db) == expected_urls
 
-    list_parser = parsers.List(pq("#images img").attr("src").items, parsers.Url())
+    list_parser = parsers.List(pq("#images img::src-items"), parsers.Url())
 
     assert list_parser.parse(db) == expected_urls
 
-    list_parser = parsers.List(pq("#images img").attr("src").items)
+    list_parser = parsers.List(pq("#images img::src-items"))
 
     assert list_parser.parse(db) == expected_urls
 
-    test_list = ["hello", "World &lt;3"]
-    assert parsers.List().parse(test_list) == ["hello", "World &lt;3"]
+    test_list_values = ["hello", "World &lt;3"]
+    assert parsers.List().parse(test_list_values) == ["hello", "World &lt;3"]
 
 
 def test_list_unique_true():
     list_parser = parsers.List(
-        pq("#image-container img").items, parsers.Url(pq(attr="src")), unique=True
+        pq("#image-container img::items"), parsers.Url(pq("::src")), unique=True
     )
 
     assert list_parser.parse(db) == expected_urls
@@ -61,8 +64,8 @@ def test_list_unique_true():
 
 def test_list_unique_default():
     list_parser = parsers.List(
-        pq("#image-container img").items,
-        parsers.Url(pq(attr="src")),
+        pq("#image-container img::items"),
+        parsers.Url(pq("::src")),
     )
 
     assert list_parser.parse(db) == expected_urls
@@ -70,7 +73,7 @@ def test_list_unique_default():
 
 def test_list_unique_false():
     list_parser = parsers.List(
-        pq("#image-container img").items, parsers.Url(pq(attr="src")), unique=False
+        pq("#image-container img::items"), parsers.Url(pq("::src")), unique=False
     )
 
     assert list_parser.parse(db) == expected_urls_non_unique
@@ -78,7 +81,7 @@ def test_list_unique_false():
 
 def test_list_max_num():
     list_parser = parsers.List(
-        pq("#image-container img").items, parsers.Url(pq(attr="src")), max_num=2
+        pq("#image-container img::items"), parsers.Url(pq("::src")), max_num=2
     )
 
     assert list_parser.parse(db) == expected_urls_max_2

--- a/tests/parsers/test_list.py
+++ b/tests/parsers/test_list.py
@@ -35,10 +35,7 @@ expected_urls_max_2 = ["https://demo.com/imgs/1.jpg", "https://demo.com/imgs/2.j
 
 
 def test_list():
-    list_parser = parsers.List(
-        pq("#images img::items"),
-        parsers.Url(pq("::src"))
-    )
+    list_parser = parsers.List(pq("#images img::items"), parsers.Url(pq("::src")))
 
     assert list_parser.parse(db) == expected_urls
 

--- a/tests/processors/test_data.py
+++ b/tests/processors/test_data.py
@@ -159,7 +159,7 @@ def test_data_variant_processor_multi_values() -> None:
 
     # Lets test with HTML data and pq selector
     db = processors.DataVariantProcessor(
-        query=pq("#color-variants .color").items, variant_query=pq().text
+        query=pq("#color-variants .color::items"), variant_query=pq("::text")
     ).parse_data(test_variants_html_data)
 
     assert isinstance(db["data_variants"], dict)

--- a/tests/queries/test_pq.py
+++ b/tests/queries/test_pq.py
@@ -7,7 +7,7 @@ test_html = """
                 <div class="brand">EasyData</div>
                 Test Product Item
             </h2>
-            <input value="smartphone" name="category" />
+            <input value="smartphone" content="phone" name="category" />
             <a id="url" href="http://demo.com/product/123">Item Link</a>
             <div class="images">
                 <img src="http://demo.com/img1.jpg" />
@@ -25,51 +25,58 @@ exp_result_images = [
 ]
 
 
-def test_pq_query_get_text():
-    assert pq(".brand").text.get(test_html) == "EasyData"
-    assert pq(".brand", text=True).get(test_html) == "EasyData"
+def test_pq_query_text():
+    assert pq(".brand::text").get(test_html) == "EasyData"
 
 
-def test_pq_query_get_attr():
+def test_pq_query_attr():
     exp_result = "smartphone"
-    assert pq('[name="category"]').attr("value").get(test_html) == exp_result
-    assert pq('[name="category"]', attr="value").get(test_html) == exp_result
+    assert pq('[name="category"]::attr(value)').get(test_html) == exp_result
 
 
-def test_pq_query_get_val():
-    result = pq('[name="category"]').val.get(test_html)
+def test_pq_query_attr_val():
+    result = pq('[name="category"]::val').get(test_html)
     assert result == "smartphone"
 
 
-def test_pq_query_get_src():
-    result = pq(".images img").src.get(test_html)
+def test_pq_query_attr_name():
+    result = pq('[name="category"]::name').get(test_html)
+    assert result == "category"
+
+
+def test_pq_query_attr_content():
+    result = pq('[name="category"]::content').get(test_html)
+    assert result == "phone"
+
+
+def test_pq_query_attr_src():
+    result = pq(".images img::src").get(test_html)
     assert result == "http://demo.com/img1.jpg"
 
 
-def test_pq_query_get_href():
-    result = pq("#url").href.get(test_html)
+def test_pq_query_attr_href():
+    result = pq("#url::href").get(test_html)
     assert result == "http://demo.com/product/123"
 
 
-def test_pq_query_get_rm():
+def test_pq_query_rm():
     exp_result = "Test Product Item"
-    assert pq(".name", rm=".brand").text.get(test_html) == exp_result
+    assert pq(".name::text", rm=".brand").get(test_html) == exp_result
 
 
-def test_pq_query_get_rm_method():
+def test_pq_query_rm_method():
     exp_result = "Test Product Item"
-    assert pq(".name").rm(".brand").text.get(test_html) == exp_result
+    assert pq(".name::text").rm(".brand").get(test_html) == exp_result
 
 
-def test_pq_query_get_html():
+def test_pq_query_html():
     exp_result = '<div class="brand">EasyData</div>\nTest Product Item'
-    assert pq(".name").html.get(test_html).strip().replace("  ", "") == exp_result
-    assert pq(".name", html=True).get(test_html).strip().replace("  ", "") == exp_result
+    assert pq(".name::html").get(test_html).strip().replace("  ", "") == exp_result
 
 
-def test_pq_query_get_all_src():
-    assert pq(".images img").src.get_all(test_html) == exp_result_images
+def test_pq_query_src_get_all():
+    assert pq(".images img::src").get_all(test_html) == exp_result_images
 
 
-def test_pq_query_get_iter_src():
-    assert list(pq(".images img").src.get_iter(test_html)) == exp_result_images
+def test_pq_query_src_get_iter():
+    assert list(pq(".images img::src").get_iter(test_html)) == exp_result_images

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -14,9 +14,9 @@ test_html = """
 
 
 class PricingBlock(Block):
-    item_price = parsers.PriceFloat(pq("#price").text)
+    item_price = parsers.PriceFloat(pq("#price::text"))
 
-    item_sale_price = parsers.PriceFloat(pq("#sale-price").text)
+    item_sale_price = parsers.PriceFloat(pq("#sale-price::text"))
 
     items_processors = [("discount", ItemDiscountProcessor())]
 


### PR DESCRIPTION
- redesign pq query selector so that now supports type of data return from pseudo keys
- removed old way how to specify type of data return in a pq
- updated tests to address pseudo keys in a pq
- updated docs to address pseudo keys in a pq