### PR TITLE
add-all-to-pq-query

### DIFF
--- a/easydata/queries/pq.py
+++ b/easydata/queries/pq.py
@@ -16,11 +16,7 @@ _attr_shortcut_mappings = {
 
 
 class PyQuerySearch(QuerySearch):
-    def __init__(
-        self,
-        query: Optional[str] = None,
-        rm: Optional[str] = None
-    ):
+    def __init__(self, query: Optional[str] = None, rm: Optional[str] = None):
 
         self._query = query
         self._rm_query = rm

--- a/easydata/queries/pq.py
+++ b/easydata/queries/pq.py
@@ -19,14 +19,13 @@ class PyQuerySearch(QuerySearch):
     def __init__(
         self,
         query: Optional[str] = None,
-        rm: Optional[str] = None,
-        first: bool = True,
+        rm: Optional[str] = None
     ):
 
         self._query = query
         self._rm_query = rm
-        self._first = first
 
+        self._first = True
         self._attr = None
         self._text = False
         self._ntext = False
@@ -124,6 +123,10 @@ class PyQuerySearch(QuerySearch):
             pseudo_key = pseudo_key.split("-")[0]
 
             self._items = True
+        elif "-all" in pseudo_key:
+            pseudo_key = pseudo_key.split("-")[0]
+
+            self._first = False
 
         if pseudo_key.startswith("attr"):
             attr_value = pseudo_key.split("(")[-1].strip(")")

--- a/tests/queries/test_pq.py
+++ b/tests/queries/test_pq.py
@@ -3,6 +3,11 @@ from easydata.queries import pq
 test_html = """
     <html>
         <body>
+            <div class="breadcrumbs">
+                <div class="breadcrumb">Home</div>
+                <div class="breadcrumb">Phone</div>
+                <div class="breadcrumb">Smartphone</div>
+            </div>
             <h2 class="name">
                 <div class="brand">EasyData</div>
                 Test Product Item
@@ -27,6 +32,15 @@ exp_result_images = [
 
 def test_pq_query_text():
     assert pq(".brand::text").get(test_html) == "EasyData"
+
+
+def test_pq_query_all():
+    # Test default
+    assert pq(".breadcrumbs .breadcrumb::text").get(test_html) == "Home"
+
+    # Test all
+    result = "Home Phone Smartphone"
+    assert pq(".breadcrumbs .breadcrumb::text-all").get(test_html) == result
 
 
 def test_pq_query_attr():


### PR DESCRIPTION
By default pq will select text from first match and in order to disable this behaviour 
we need to set `first=False`. Now we can just set `::text-all` to reproduce this behaviour.