### PR TITLE
option to ignore item attr by prefix

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -52,7 +52,7 @@ data from the HTML above.
             pq('#sale-price::text')
         )
 
-        items_processors = [
+        item_processors = [
             ('discount', ItemDiscountProcessor())
         ]
 
@@ -116,7 +116,7 @@ If needed, we can easily disable ``ItemDiscountProcessor`` in our ``ProductItemM
             PricingBlockModel()
         ]
 
-        items_processors = [
+        item_processors = [
             ('discount', None)
         ]
 
@@ -208,7 +208,7 @@ For starters lets create *block models* without named item processors.
             pq('#sale-price::text')
         )
 
-        items_processors = [
+        item_processors = [
             ItemDiscountProcessor()
         ]
 
@@ -223,7 +223,7 @@ with custom parameters in our model.
             PricingBlockModel()
         ]
 
-        items_processors = [
+        item_processors = [
             ItemDiscountProcessor(no_decimals=True)
         ]
 
@@ -231,7 +231,7 @@ with custom parameters in our model.
 
 In this case ``ItemDiscountProcessor`` from our ``ProductItemModel`` would be joined
 together with the same processor from the ``PricingBlockModel``. For better understanding
-lets just show a list how ``items_processors`` behind the scene look like now.
+lets just show a list how ``item_processors`` behind the scene look like now.
 
 .. code-block:: python
 
@@ -257,7 +257,7 @@ To solve this issue, named processors are the solution. Lets recreate our
             pq('#sale-price::text')
         )
 
-        items_processors = [
+        item_processors = [
             ('discount', ItemDiscountProcessor())
         ]
 
@@ -271,7 +271,7 @@ we just assign same name to our ``ItemDiscountProcessor`` as it is in ``PricingB
             PricingBlockModel()
         ]
 
-        items_processors = [
+        item_processors = [
             ('discount', ItemDiscountProcessor(no_decimals=True))
         ]
 
@@ -289,7 +289,7 @@ adding ``None`` to our named key in ``tuple`` as we can see in example bellow.
             PricingBlockModel()
         ]
 
-        items_processors = [
+        item_processors = [
             ('discount', None)
         ]
 
@@ -316,7 +316,7 @@ Lets show this in example below.
             pq('#sale-price::text')
         )
 
-        items_processors = [
+        item_processors = [
             ItemDiscountProcessor()
         ]
 
@@ -447,8 +447,8 @@ Follow example bellow to get more info regarding these two methods.
     }
 
 Now lets create our model which will process our ``test_dict``. With a ``preprocess_item``
-we will modify item dictionary before ``items_processors`` are fired so that we can prepare
-item in order to be used in  ``items_processors``. In example bellow we will fix wrong sale
+we will modify item dictionary before ``item_processors`` are fired so that we can prepare
+item in order to be used in  ``item_processors``. In example bellow we will fix wrong sale
 price, so that ``ItemDiscountProcessor`` can properly calculate discount and later we will
 utilize ``process_item`` method, where new dictionary item ``final_sale`` will be created
 with bool value, which is determined if price is discounted or not.
@@ -460,7 +460,7 @@ with bool value, which is determined if price is discounted or not.
 
         item_temp_sale_price = parsers.PriceFloat(jp('sale_price'))
 
-        items_processors = [
+        item_processors = [
             ItemDiscountProcessor()
         ]
 
@@ -497,7 +497,7 @@ Output:
 .. note::
     *Please note that sale_price is missing in final output because we declared in
     a model our sale price property as a temporary and those get deleted at the end,
-    but they are still accessible in ``preprocess_item``, ``items_processors`` and
+    but they are still accessible in ``preprocess_item``, ``item_processors`` and
     ``process_item``.*
 
 Variants

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -48,7 +48,7 @@ through other components.
             source='html'
         )
 
-        items_processors = [
+        item_processors = [
             ItemDiscountProcessor()
         ]
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -366,7 +366,7 @@ In this example we will use following html:
         </html>
     """
 
-Lets create our item model with ``items_processors``
+Lets create our item model with ``item_processors``
 
 .. code-block:: python
 
@@ -392,7 +392,7 @@ Lets create our item model with ``items_processors``
             pq('#sale-price::text')
         )
 
-        items_processors = [
+        item_processors = [
             ItemDiscountProcessor()
         ]
 
@@ -422,7 +422,7 @@ Lets see how ``ItemDiscountProcessor`` works in more detail.
 .. code-block:: python
 
         ...
-        items_processors = [
+        item_processors = [
             ItemDiscountProcessor()
         ]
 
@@ -439,7 +439,7 @@ We can also specify multiple items processors if needed:
 
 .. code-block:: python
 
-    items_processors = [
+    item_processors = [
         ItemDiscountProcessor(),
         ItemKeysMergeIntoDictProcessor(
             new_item_key='price_info',
@@ -448,7 +448,7 @@ We can also specify multiple items processors if needed:
         )
     ]
 
-``items_processors`` in above example would produce following output:
+``item_processors`` in above example would produce following output:
 
 .. code-block:: python
 

--- a/easydata/managers.py
+++ b/easydata/managers.py
@@ -11,7 +11,7 @@ __all__ = ("ModelManager",)
 
 
 class ModelManager(ConfigMixin):
-    _ignore_item_attr_prefix = ['item_processors']
+    _ignore_item_attr_prefix = ["item_processors"]
 
     def __init__(self, model):
         self._model = model
@@ -30,7 +30,7 @@ class ModelManager(ConfigMixin):
         self._init_model(model)
 
         self._init_config()
-        
+
         self._init_parsers_config()
 
     @property
@@ -146,7 +146,7 @@ class ModelManager(ConfigMixin):
         if model.block_models:
             for model_block in model.block_models:
                 self._init_model(model_block)
-                
+
         model.init_model()
 
         self._load_item_parsers_from_model(model)
@@ -165,7 +165,7 @@ class ModelManager(ConfigMixin):
 
     def _init_config(self):
         self.init_config(self._config_properties)
-    
+
     def _init_parsers_config(self):
         for parser_instance in self._item_parsers.values():
             if isinstance(parser_instance, BaseParser):

--- a/easydata/models.py
+++ b/easydata/models.py
@@ -12,7 +12,7 @@ class BaseModel(ABC):
 
     data_processors: List[DataBaseProcessor] = []
 
-    items_processors: List[BaseProcessor] = []
+    item_processors: List[BaseProcessor] = []
 
     _model_manager: Optional[ModelManager] = None
 
@@ -27,6 +27,12 @@ class BaseModel(ABC):
 
     def process_item(self, item: dict):
         return item
+
+    def init_model(self):
+        pass
+
+    def initialized_model(self):
+        pass
 
     @property
     def model_manager(self):

--- a/easydata/utils/mix.py
+++ b/easydata/utils/mix.py
@@ -92,11 +92,19 @@ def apply_processors(
     return value
 
 
-def extract_attr_names_from_obj(obj: object, attr_prefix: str):
+def extract_attr_names_from_obj(
+    obj: object,
+    attr_prefix: str,
+    ignore_attr_prefix: Optional[List[str]] = None,
+):
 
     attr_names = []
 
     for attr_name in dir(obj):
+        if ignore_attr_prefix:
+            if any(attr_name.startswith(sk) for sk in ignore_attr_prefix):
+                continue
+
         if attr_name.startswith(attr_prefix + "_"):
             attr_names.append(attr_name)
 
@@ -104,10 +112,17 @@ def extract_attr_names_from_obj(obj: object, attr_prefix: str):
 
 
 def iter_attr_data_from_obj(
-    obj: object, attr_prefix: str, preserve_prefix: bool = False
+    obj: object,
+    attr_prefix: str,
+    preserve_prefix: bool = False,
+    ignore_attr_prefix: Optional[List[str]] = None,
 ):
 
-    attr_name = extract_attr_names_from_obj(obj=obj, attr_prefix=attr_prefix)
+    attr_name = extract_attr_names_from_obj(
+        obj=obj,
+        attr_prefix=attr_prefix,
+        ignore_attr_prefix=ignore_attr_prefix,
+    )
 
     for attr_name in attr_name:
         attr_value = getattr(obj, attr_name)

--- a/tests/factory/models.py
+++ b/tests/factory/models.py
@@ -43,7 +43,7 @@ class ProductSimpleWithProcessItemModel(ItemModel):
 
     item_temp_sale_price = parsers.PriceFloat(jp("sale_price"))
 
-    items_processors = [ItemDiscountProcessor()]
+    item_processors = [ItemDiscountProcessor()]
 
     def preprocess_item(self, item):
         if item["sale_price"] <= 1:
@@ -62,7 +62,7 @@ class PricingBlockModel(ItemModel):
 
     item_sale_price = parsers.PriceFloat(pq("#sale-price::text"))
 
-    items_processors = [("discount", ItemDiscountProcessor())]
+    item_processors = [("discount", ItemDiscountProcessor())]
 
 
 class SettingsBlockModel(ItemModel):


### PR DESCRIPTION
* option to ignore item attr by prefix
* rename `items_processors` to `item_processor`
* update docs regarding renaming
* expose `init_model` and `initialized_model` methods in item model
    - `init_model` will be called before model processors and parsers are initialized by model manager
    - `initialized_model` will be called after models processors and parsers are initialized by model manager